### PR TITLE
Adding missing include to compile Demo

### DIFF
--- a/Demo/Source/Main.cpp
+++ b/Demo/Source/Main.cpp
@@ -4,6 +4,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <docks/docks.h>
 #include <../../docks/tests/catch2.hpp>
+#include "JuceHeader.h"
 
 /**
  -------------------------------------------------------------


### PR DESCRIPTION
Hi Christopher! Absolutely love what your're doing and I am set to include the docks system in my KnobKraft Orm, which severly is impeded by having no flexible window layout. My first try outs to include it were unsuccessful however, so today I looked at your demo app, and that works nicely with Juce 7.0.3, with the change in this PR.

What are your requirements in regards to Juce version, would 6.1.6 work as well?